### PR TITLE
Merge include-paths-bidib (and onion) CMake integration update

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_FLAGS "-Wall -Wno-gnu-folding-constant")
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 
-include(FindPkgConfig)
+find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(GLIB glib-2.0 REQUIRED)
 include_directories(${GLIB_INCLUDE_DIRS})

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -19,51 +19,29 @@ pkg_check_modules(CMOCKA cmocka REQUIRED)
 include_directories(${CMOCKA_INCLUDE_DIRS})
 link_directories(${CMOCKA_LIBRARY_DIRS})
 
-# Include bibib libraries. Relies on Bidib having been installed prior.
-pkg_check_modules(libbidib REQUIRED IMPORTED_TARGET bidib)
-pkg_check_modules(libbidib_static REQUIRED IMPORTED_TARGET bidib_static)
-include_directories(${LIBBIDIB_INCLUDE_DIRS})
+# Include BiDiB library that have been installed
+pkg_check_modules(BIDIB bidib REQUIRED)
+include_directories(${BIDIB_INCLUDE_DIRS})
+link_directories(${BIDIB_LIBRARY_DIRS})
+
+pkg_check_modules(ONION onion REQUIRED)
+include_directories(${ONION_INCLUDE_DIRS})
+link_directories(${ONION_LIBRARY_DIRS})
 
 IF (APPLE)
-	set(LIBRARY_DIR /usr/local/Cellar)
+	pkg_check_modules(LIBGCRYPT libgcrypt REQUIRED)
+	include_directories(${LIBGCRYPT_INCLUDE_DIRS})
+	link_directories(${LIBGCRYPT_LIBRARY_DIRS})
 
-	# Manually add the include and library directories for libgcrypt
-	include_directories(${LIBRARY_DIR}/libgcrypt/1.10.1/include)
-	link_directories(${LIBRARY_DIR}/libgcrypt/1.10.1/lib)
-
-	# Manually add the include and library directories for yaml
-	include_directories(${LIBRARY_DIR}/libyaml/0.2.5/include)
-	link_directories(${LIBRARY_DIR}/libyaml/0.2.5/lib)
+	pkg_check_modules(YAML yaml-0.1 REQUIRED)
+	include_directories(${YAML_INCLUDE_DIRS})
+	link_directories(${YAML_LIBRARY_DIRS})
 
 	# Manually add the include and library directories for libev
 	set(LINK_EV ev)
-	include_directories(${LIBRARY_DIR}/libev/4.33/include)
-	link_directories(${LIBRARY_DIR}/libev/4.33/lib)
-	
-	# Manually add the include and library directories for onion
-	set(LIBRARY_DIR /Users/eugeneyip/Documents/SWTbahn/Software)
-	include_directories(${LIBRARY_DIR}/onion/src)
-	link_directories(${LIBRARY_DIR}/onion/bin/src/onion)
-
-	set(LIBONION_DIR ${LIBRARY_DIR}/onion)
-	add_library(onion_static STATIC IMPORTED)
-	set_target_properties(onion_static PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-		${LIBONION_DIR}/src)
-	set_target_properties(onion_static PROPERTIES IMPORTED_LOCATION
-		${LIBONION_DIR}/bin/src/onion/libonion_static${CMAKE_STATIC_LIBRARY_SUFFIX})
-
-	add_library(onion SHARED IMPORTED)
-	set_target_properties(onion PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-		${LIBONION_DIR}/src)
-	set_target_properties(onion PROPERTIES IMPORTED_LOCATION
-		${LIBONION_DIR}/bin/src/onion/libonion${CMAKE_SHARED_LIBRARY_SUFFIX})
-	
-
-ELSE ()
-	pkg_check_modules(libonion REQUIRED IMPORTED_TARGET onion)
-	pkg_check_modules(libonion_static REQUIRED IMPORTED_TARGET onion_static)
-	include_directories(${LIBONION_INCLUDE_DIRS})
-
+	set(LIB_EV_DIR /usr/local/Cellar/libev/4.33)
+	include_directories(${LIB_EV_DIR}/include)
+	link_directories(${LIB_EV_DIR}/lib)
 ENDIF (APPLE)
 
 file(GLOB SRCFILES "src/*.c" "src/parsers/*.c")
@@ -71,6 +49,9 @@ file(GLOB SRCFILES "src/*.c" "src/parsers/*.c")
 set_directory_properties(PROPERTIES ADDITIONAL_CLEAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/engines;${CMAKE_CURRENT_BINARY_DIR}/interlockers")
 
 
+# - - - - - - - - - - - - -
+ # ADJUSTMENT SECTION BEGIN
+ # - - - - - - - - - - - - -
 
 set(FOREC_MAIN dyn_containers)
 set(FOREC_SRC ${CMAKE_SOURCE_DIR}/src)
@@ -93,10 +74,10 @@ add_custom_target(
 	COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/interlockers"
 )
 
-
 # - - - - - - - - - - - - -
 # ADJUSTMENT SECTION END
 # - - - - - - - - - - - - -
+
 
 add_library(${FOREC_MAIN} SHARED ${SRCFILES} ${FOREC_MAIN}.c)
 target_include_directories(${FOREC_MAIN} PRIVATE src)

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -19,6 +19,11 @@ pkg_check_modules(CMOCKA cmocka REQUIRED)
 include_directories(${CMOCKA_INCLUDE_DIRS})
 link_directories(${CMOCKA_LIBRARY_DIRS})
 
+# Include bibib libraries. Relies on Bidib having been installed prior.
+pkg_check_modules(libbidib REQUIRED IMPORTED_TARGET bidib)
+pkg_check_modules(libbidib_static REQUIRED IMPORTED_TARGET bidib_static)
+include_directories(${LIBBIDIB_INCLUDE_DIRS})
+
 IF (APPLE)
 	set(LIBRARY_DIR /usr/local/Cellar)
 
@@ -39,8 +44,26 @@ IF (APPLE)
 	set(LIBRARY_DIR /Users/eugeneyip/Documents/SWTbahn/Software)
 	include_directories(${LIBRARY_DIR}/onion/src)
 	link_directories(${LIBRARY_DIR}/onion/bin/src/onion)
+
+	set(LIBONION_DIR ${LIBRARY_DIR}/onion)
+	add_library(onion_static STATIC IMPORTED)
+	set_target_properties(onion_static PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+		${LIBONION_DIR}/src)
+	set_target_properties(onion_static PROPERTIES IMPORTED_LOCATION
+		${LIBONION_DIR}/bin/src/onion/libonion_static${CMAKE_STATIC_LIBRARY_SUFFIX})
+
+	add_library(onion SHARED IMPORTED)
+	set_target_properties(onion PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+		${LIBONION_DIR}/src)
+	set_target_properties(onion PROPERTIES IMPORTED_LOCATION
+		${LIBONION_DIR}/bin/src/onion/libonion${CMAKE_SHARED_LIBRARY_SUFFIX})
+	
+
 ELSE ()
-	set(LIBRARY_DIR /home/pi/SWTbahn)
+	pkg_check_modules(libonion REQUIRED IMPORTED_TARGET onion)
+	pkg_check_modules(libonion_static REQUIRED IMPORTED_TARGET onion_static)
+	include_directories(${LIBONION_INCLUDE_DIRS})
+
 ENDIF (APPLE)
 
 file(GLOB SRCFILES "src/*.c" "src/parsers/*.c")
@@ -48,35 +71,6 @@ file(GLOB SRCFILES "src/*.c" "src/parsers/*.c")
 set_directory_properties(PROPERTIES ADDITIONAL_CLEAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/engines;${CMAKE_CURRENT_BINARY_DIR}/interlockers")
 
 
-# - - - - - - - - - - - - -
-# ADJUSTMENT SECTION BEGIN
-# - - - - - - - - - - - - -
-
-set(LIBONION_DIR ${LIBRARY_DIR}/onion)
-add_library(onion_static STATIC IMPORTED)
-set_target_properties(onion_static PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-	${LIBONION_DIR}/src)
-set_target_properties(onion_static PROPERTIES IMPORTED_LOCATION
-	${LIBONION_DIR}/bin/src/onion/libonion_static${CMAKE_STATIC_LIBRARY_SUFFIX})
-
-add_library(onion SHARED IMPORTED)
-set_target_properties(onion PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-	${LIBONION_DIR}/src)
-set_target_properties(onion PROPERTIES IMPORTED_LOCATION
-	${LIBONION_DIR}/bin/src/onion/libonion${CMAKE_SHARED_LIBRARY_SUFFIX})
-
-set(LIBBIDIB_DIR ${LIBRARY_DIR}/libbidib)
-add_library(bidib_static STATIC IMPORTED)
-set_target_properties(bidib_static PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-	${LIBBIDIB_DIR}/include)
-set_target_properties(bidib_static PROPERTIES IMPORTED_LOCATION
-	${LIBBIDIB_DIR}/bin/libbidib_static${CMAKE_STATIC_LIBRARY_SUFFIX})
-
-add_library(bidib SHARED IMPORTED)
-set_target_properties(bidib PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-	${LIBBIDIB_DIR}/include)
-set_target_properties(bidib PROPERTIES IMPORTED_LOCATION
-	${LIBBIDIB_DIR}/bin/libbidib${CMAKE_SHARED_LIBRARY_SUFFIX})
 
 set(FOREC_MAIN dyn_containers)
 set(FOREC_SRC ${CMAKE_SOURCE_DIR}/src)

--- a/server/src/bahn_data_util.c
+++ b/server/src/bahn_data_util.c
@@ -25,7 +25,7 @@
  *
  */
 
-#include <bidib.h>
+#include <bidib/bidib.h>
 #include <string.h>
 
 #include "server.h"

--- a/server/src/dyn_containers_interface.c
+++ b/server/src/dyn_containers_interface.c
@@ -31,7 +31,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <glib.h>
-#include <bidib.h>
+#include <bidib/bidib.h>
 
 #include "dyn_containers_interface.h"
 #include "handler_admin.h"

--- a/server/src/handler_admin.c
+++ b/server/src/handler_admin.c
@@ -26,7 +26,7 @@
  */
 
 #include <onion/onion.h>
-#include <bidib.h>
+#include <bidib/bidib.h>
 #include <pthread.h>
 #include <unistd.h>
 #include <stdio.h>

--- a/server/src/handler_controller.c
+++ b/server/src/handler_controller.c
@@ -28,7 +28,7 @@
 
 #include <unistd.h>
 #include <onion/onion.h>
-#include <bidib.h>
+#include <bidib/bidib.h>
 #include <pthread.h>
 #include <string.h>
 

--- a/server/src/handler_driver.c
+++ b/server/src/handler_driver.c
@@ -26,7 +26,7 @@
  */
 
 #include <onion/onion.h>
-#include <bidib.h>
+#include <bidib/bidib.h>
 #include <pthread.h>
 #include <unistd.h>
 #include <glib.h>

--- a/server/src/handler_monitor.c
+++ b/server/src/handler_monitor.c
@@ -26,7 +26,7 @@
  */
 
 #include <onion/onion.h>
-#include <bidib.h>
+#include <bidib/bidib.h>
 #include <pthread.h>
 #include <unistd.h>
 #include <glib.h>

--- a/server/src/interlocking.c
+++ b/server/src/interlocking.c
@@ -26,7 +26,7 @@
  *
  */
 
-#include <bidib.h>
+#include <bidib/bidib.h>
 #include <glib.h>
 #include <string.h>
 #include <stdio.h>

--- a/server/src/server.c
+++ b/server/src/server.c
@@ -30,7 +30,7 @@
 #include <onion/log.h>
 #include <onion/low.h>
 #include <signal.h>
-#include <bidib.h>
+#include <bidib/bidib.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <string.h>

--- a/server/test/unit/server_bahn_util_tests.c
+++ b/server/test/unit/server_bahn_util_tests.c
@@ -30,7 +30,7 @@
 #include <setjmp.h>
 #include <stdarg.h>
 #include <cmocka.h>
-#include <bidib.h>
+#include <bidib/bidib.h>
 
 #include "../../src/bahn_data_util.h"
 

--- a/server/test/unit/server_parser_tests.c
+++ b/server/test/unit/server_parser_tests.c
@@ -30,7 +30,7 @@
 #include <setjmp.h>
 #include <stdarg.h>
 #include <cmocka.h>
-#include <bidib.h>
+#include <bidib/bidib.h>
 
 #include "../../src/bahn_data_util.h"
 


### PR DESCRIPTION
This updates the CMake setup of this project to look for libbidib and libonion using pkg-config. This change is motivated by the fact that the current integration is (at least partially) hardcoded, and thus a bit annoying to set up on new dev machines.

With this change, we do require use of the most recent changes in libonion ([link](https://github.com/uniba-swt/onion)). The previous versions of onion only installed the non-static version with pkg-config.

The most important changes in the [CMakeLists.txt](https://github.com/uniba-swt/swtbahn-cli/blob/69-include-paths-bidib/server/CMakeLists.txt) are thus:
- Lines 23-25: Pkg-config based loading of bidib and bidib_static,
- Lines 63-65: Pkg-config based loading of onion and onion_static _for non-apple users_.


Due to how bidib is installed, the include paths in .h and .c files of the swtbahn-cli server must be adjusted. Previously, bidib.h was located in e.g. `/usr/local/include` (on KUbuntu 22.04 in this case). With the update to libbidib pkg-config use, it is now installed to (again, Kubuntu 22.04)` /usr/local/include/bidib/` - so the `#include` statements must change from <bidib.h> to <bidib/bidib.h>. This is consistent with how onion has to be included (`<onion/onion.h>`).


I've not been able to test the onion pkg-config integration for Apple machines so far. I'd be great if @eyip002 could test whether it works and adjust that part of the CMakeLists.txt accordingly. The changes in the include paths are likely to not work for Apple/Mac users otherwise (the current semi-hardcoded inclusion of onion could be adjusted to fix that however).

Closes #69 