### PR TITLE
Header file includes and header guards fixes

### DIFF
--- a/server/src/bahn_data_util.h
+++ b/server/src/bahn_data_util.h
@@ -84,4 +84,4 @@ void log_float(float value);
 
 void log_string(const char *value);
 
-#endif // BAHN_DATA_UTIL_H
+#endif  // BAHN_DATA_UTIL_H

--- a/server/src/check_route_sectional/check_route_sectional_direct.h
+++ b/server/src/check_route_sectional/check_route_sectional_direct.h
@@ -25,8 +25,8 @@
  *
  */
 
-#ifndef _CHECK_ROUTE_SECTIONAL_DIRECT_H
-#define _CHECK_ROUTE_SECTIONAL_DIRECT_H
+#ifndef CHECK_ROUTE_SECTIONAL_DIRECT_H
+#define CHECK_ROUTE_SECTIONAL_DIRECT_H
 
 #include <stdbool.h>
 
@@ -41,4 +41,4 @@
  */
 bool is_route_conflict_safe_sectional(const char *granted_route_id, const char *requested_route_id);
 
-#endif // _CHECK_ROUTE_SECTIONAL_DIRECT_H
+#endif  // CHECK_ROUTE_SECTIONAL_DIRECT_H

--- a/server/src/dyn_containers.h
+++ b/server/src/dyn_containers.h
@@ -25,8 +25,12 @@
  *
  */
 
-#ifndef SWTSERVER_DYN_CONTAINERS_H
-#define SWTSERVER_DYN_CONTAINERS_H
+#ifndef DYN_CONTAINERS_H
+#define DYN_CONTAINERS_H
+
+#include <pthread.h>
+#include <stdbool.h>
+#include <limits.h>
 
 // Copy of the data structures defined in the generated C code of dyn_containers.forec.
 
@@ -160,4 +164,4 @@ extern Core mainParCore2;
 
 extern int mainParReactionCounter;
 
-#endif
+#endif  // DYN_CONTAINERS_H

--- a/server/src/dyn_containers_interface.h
+++ b/server/src/dyn_containers_interface.h
@@ -196,4 +196,4 @@ void dyn_containers_set_interlocker_instance_inputs(t_interlocker_data * const i
 void dyn_containers_get_interlocker_instance_outputs(t_interlocker_data * const interlocker_instance, 
                                                      struct t_interlocker_instance_io *interlocker_instance_io_copy);
 
-#endif	// DYN_CONTAINERS_INTERFACE_H
+#endif  // DYN_CONTAINERS_INTERFACE_H

--- a/server/src/handler_admin.h
+++ b/server/src/handler_admin.h
@@ -25,8 +25,10 @@
  *
  */
 
-#ifndef SWTSERVER_HANDLER_ADMIN_H
-#define SWTSERVER_HANDLER_ADMIN_H
+#ifndef HANDLER_ADMIN_H
+#define HANDLER_ADMIN_H
+
+#include <onion/onion.h>
 
 void stop_bidib(void);
 
@@ -46,5 +48,4 @@ onion_connection_status handler_admin_set_dcc_train_speed(void *_, onion_request
                                                           onion_response *res);
 
 
-#endif
-
+#endif  // HANDLER_ADMIN_H

--- a/server/src/handler_controller.h
+++ b/server/src/handler_controller.h
@@ -26,11 +26,14 @@
  *
  */
 
-#ifndef SWTSERVER_HANDLER_CONTROLLER_H
-#define SWTSERVER_HANDLER_CONTROLLER_H
+#ifndef HANDLER_CONTROLLER_H
+#define HANDLER_CONTROLLER_H
 
 #define INTERLOCKER_COUNT_MAX           4
 #define INTERLOCKER_INSTANCE_COUNT_MAX  4
+
+#include <onion/onion.h>
+#include <glib.h>
 
 extern pthread_mutex_t interlocker_mutex;
 
@@ -138,5 +141,5 @@ onion_connection_status handler_set_interlocker(void *_, onion_request *req,
 onion_connection_status handler_unset_interlocker(void *_, onion_request *req,
                                                   onion_response *res);
 
-#endif	// SWTSERVER_HANDLER_CONTROLLER_H
+#endif  // HANDLER_CONTROLLER_H
 

--- a/server/src/handler_driver.h
+++ b/server/src/handler_driver.h
@@ -25,8 +25,8 @@
  *
  */
 
-#ifndef SWTSERVER_HANDLER_DRIVER_H
-#define SWTSERVER_HANDLER_DRIVER_H
+#ifndef HANDLER_DRIVER_H
+#define HANDLER_DRIVER_H
 
 #include <onion/onion.h>
 #include <glib.h>
@@ -86,5 +86,4 @@ onion_connection_status handler_set_train_emergency_stop(void *_, onion_request 
                                                          onion_response *res);
 
 
-#endif
-
+#endif  // HANDLER_DRIVER_H

--- a/server/src/handler_monitor.h
+++ b/server/src/handler_monitor.h
@@ -25,8 +25,8 @@
  *
  */
 
-#ifndef SWTSERVER_HANDLER_GETTER_H
-#define SWTSERVER_HANDLER_GETTER_H
+#ifndef HANDLER_MONITOR_H
+#define HANDLER_MONITOR_H
 
 #include "dyn_containers_interface.h"
 #include "dyn_containers.h"
@@ -81,5 +81,5 @@ onion_connection_status handler_get_debug_info(void *_, onion_request *req,
 onion_connection_status handler_get_debug_info_extra(void *_, onion_request *req,
                                                      onion_response *res);
 
-#endif
+#endif  // HANDLER_MONITOR_H
 

--- a/server/src/handler_upload.h
+++ b/server/src/handler_upload.h
@@ -26,8 +26,10 @@
  *
  */
 
-#ifndef SWTSERVER_HANDLER_UPLOAD_H
-#define SWTSERVER_HANDLER_UPLOAD_H
+#ifndef HANDLER_UPLOAD_H
+#define HANDLER_UPLOAD_H
+
+#include <onion/onion.h>
 
 extern pthread_mutex_t dyn_containers_mutex;
 
@@ -54,5 +56,5 @@ onion_connection_status handler_remove_interlocker(void *_, onion_request *req,
                                                    onion_response *res);
 
 
-#endif	// SWTSERVER_HANDLER_UPLOAD_H
+#endif  // HANDLER_UPLOAD_H
 

--- a/server/src/interlocking.h
+++ b/server/src/interlocking.h
@@ -115,5 +115,5 @@ int interlocking_table_get_route_id(const char *source_id, const char *destinati
  */
 t_interlocking_route *get_route(const char *route_id);
 
-#endif // INTERLOCKING_H
+#endif  // INTERLOCKING_H
 

--- a/server/src/param_verification.h
+++ b/server/src/param_verification.h
@@ -25,8 +25,8 @@
  *
  */
 
-#ifndef SWTSERVER_HANDLER_ADMIN_H
-#define SWTSERVER_HANDLER_ADMIN_H
+#ifndef PARAM_VERIFICATION_H
+#define PARAM_VERIFICATION_H
 
 #include <stdbool.h>
 
@@ -48,5 +48,4 @@ const char *params_check_mode(const char *data_mode);
 bool params_check_is_number(const char *string);
 
 
-#endif	// SWTSERVER_HANDLER_ADMIN_H
-
+#endif  // PARAM_VERIFICATION_H

--- a/server/src/parsers/config_data_intern.h
+++ b/server/src/parsers/config_data_intern.h
@@ -125,4 +125,4 @@ typedef struct {
 } t_config_peripheral_type;
 
 
-#endif //CONFIG_DATA_INTERN_H
+#endif  // CONFIG_DATA_INTERN_H

--- a/server/src/parsers/config_data_parser.h
+++ b/server/src/parsers/config_data_parser.h
@@ -35,4 +35,4 @@ bool parse_config_data(const char *config_dir, t_config_data *config_data);
 
 void free_config_data(t_config_data config_data);
 
-#endif //CONFIG_DATA_PARSER_H
+#endif  // CONFIG_DATA_PARSER_H

--- a/server/src/parsers/extras_config_parser.h
+++ b/server/src/parsers/extras_config_parser.h
@@ -25,8 +25,8 @@
  *
  */
 
-#ifndef SCCHARTS_GEN_EXTRAS_CONFIG_PARSER_H
-#define SCCHARTS_GEN_EXTRAS_CONFIG_PARSER_H
+#ifndef EXTRAS_CONFIG_PARSER_H
+#define EXTRAS_CONFIG_PARSER_H
 
 #include <yaml.h>
 #include "config_data_intern.h"
@@ -35,4 +35,4 @@ void nullify_extras_config_tables(void);
 
 void parse_extras_yaml(yaml_parser_t *parser, t_config_data *data);
 
-#endif //SCCHARTS_GEN_EXTRAS_CONFIG_PARSER_H
+#endif  // EXTRAS_CONFIG_PARSER_H

--- a/server/src/parsers/interlocking_parser.h
+++ b/server/src/parsers/interlocking_parser.h
@@ -34,4 +34,4 @@
 GHashTable *parse_interlocking_table(const char *config_dir);
 
 
-#endif // INTERLOCKING_PARSER_H
+#endif  // INTERLOCKING_PARSER_H

--- a/server/src/parsers/parser_util.h
+++ b/server/src/parsers/parser_util.h
@@ -50,4 +50,5 @@ void parse_yaml_content(yaml_parser_t *parser,
 bool str_equal(const char *str1, const char *str2);
 
 float parse_float(const char *str);
-#endif //PARSER_UTIL_H
+
+#endif  // PARSER_UTIL_H

--- a/server/src/parsers/track_config_parser.h
+++ b/server/src/parsers/track_config_parser.h
@@ -25,13 +25,14 @@
  *
  */
 
-#ifndef SCCHARTS_GEN_TRACK_CONFIG_PARSER_H
-#define SCCHARTS_GEN_TRACK_CONFIG_PARSER_H
+#ifndef TRACK_CONFIG_PARSER_H
+#define TRACK_CONFIG_PARSER_H
 
+#include <yaml.h>
 #include "config_data_intern.h"
 
 void nullify_track_config_tables(void);
 
 void parse_track_yaml(yaml_parser_t *parser, t_config_data *data);
 
-#endif //SCCHARTS_GEN_TRACK_CONFIG_PARSER_H
+#endif  // TRACK_CONFIG_PARSER_H

--- a/server/src/parsers/train_config_parser.h
+++ b/server/src/parsers/train_config_parser.h
@@ -25,8 +25,8 @@
  *
  */
 
-#ifndef SCCHARTS_GEN_TRAIN_CONFIG_PARSER_H
-#define SCCHARTS_GEN_TRAIN_CONFIG_PARSER_H
+#ifndef TRAIN_CONFIG_PARSER_H
+#define TRAIN_CONFIG_PARSER_H
 
 #include <yaml.h>
 #include "config_data_intern.h"
@@ -35,4 +35,4 @@ void nullify_train_config_table(void);
 
 void parse_train_yaml(yaml_parser_t *parser, t_config_data *data);
 
-#endif //SCCHARTS_GEN_TRAIN_CONFIG_PARSER_H
+#endif  // TRAIN_CONFIG_PARSER_H

--- a/server/src/server.h
+++ b/server/src/server.h
@@ -25,8 +25,8 @@
  *
  */
 
-#ifndef SWTSERVER_SERVER_H
-#define SWTSERVER_SERVER_H
+#ifndef SERVER_H
+#define SERVER_H
 
 #include <syslog.h>
 
@@ -42,5 +42,5 @@ void syslog_server(int priority, const char *format, ...);
 void build_response_header(onion_response *res);
 
 
-#endif	// SWTSERVER_SERVER_H
+#endif  // SERVER_H
 

--- a/server/src/tick_data.h
+++ b/server/src/tick_data.h
@@ -8,6 +8,8 @@
 #ifndef TICK_DATA_H
 #define TICK_DATA_H
 
+#include <stdbool.h>
+
 typedef struct {
   int requested_speed;      // Input
   char requested_forwards;  // Input
@@ -36,4 +38,4 @@ typedef struct {
   bool terminated;          // Output (internal variable)
 } TickData_drive_route;
 
-#endif	// TICK_DATA_H
+#endif  // TICK_DATA_H


### PR DESCRIPTION
This PR contains the changes to deal with issue #115 

Additionally, whilst already dealing with the headers, I updated the header guards where necessary. This entailed making the guard names consistent with the filenames, and introducing a consistent formatting for the comment on the `#endif` at the end of each header. The formatting is `#endif  // Name_of_header_guard`, i.e. two spaces after endif followed by the comment.

Software compiles and runs, though I have not tested running any actual railway operations after this change. However, as it only touches the header includes for the language server, this really shouldn't change anything about that.

Closes #115 